### PR TITLE
Remove spaces around user input after it is partitioned

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ fn main() {
         print!("query> ");
         io::stdout().flush().unwrap();
         let user_input: String = read!("{}\n");
-        let user_input_split = user_input.trim().split(',').collect::<Vec<&str>>();
+        let user_input_split = user_input.trim().split(',').map(|s: &str| s.trim()).collect::<Vec<&str>>();
 
         if user_input == "modes" {
             util::log_info("Available modes:");

--- a/src/mappings.rs
+++ b/src/mappings.rs
@@ -180,3 +180,19 @@ pub fn get_mode(mode: &str) -> Mode {
         },
     }
 }
+
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_get_role() {
+        assert_eq!(get_role("top"), Role::Top);
+        assert_eq!(get_role("mid"), Role::Mid);
+        assert_eq!(get_role("sup"), Role::Support);
+        assert_eq!(get_role("Adc"), Role::ADCarry);
+        assert_eq!(get_role("jungle"), Role::Jungle);
+    }
+}


### PR DESCRIPTION
Basically this fixes the cases if you entered stuff like:

"Velkoz, Mid" instead of "Velkoz,mid"

The space before mid would trip up the role finding.